### PR TITLE
test fp8dqrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ We benchmark two models ([Flux.1-Dev](https://huggingface.co/black-forest-labs/F
 
 </details>
 
-With the newly added `fp8dqrow` scheme, we can bring down the inference latency to **2.966 seconds** for Flux.1 Dev (batch size:1 , steps: 28, resolution: 1024) on an H100. Additional results:
+With the newly added `fp8dqrow` scheme, we can bring down the inference latency to **2.966 seconds** for Flux.1 Dev (batch size:1 , steps: 28, resolution: 1024) on an H100.  `fp8dqrow` has more scales per tensors and less quantization error. Additional results:
 
 <details>
 <summary>Additional `fp8dqrow` results</summary>

--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ We benchmark two models ([Flux.1-Dev](https://huggingface.co/black-forest-labs/F
 
 </details>
 
+With the newly added `fp8dqrow` scheme, we can bring down the inference latency to **2.966 seconds** for Flux.1 Dev (batch size:1 , steps: 28, resolution: 1024) on an H100. Additional results:
+
+<details>
+<summary>Additional `fp8dqrow` results</summary>
+
+|    | ckpt_id                      |   batch_size | fuse   | compile   | compile_vae   | quantization   | sparsify   |   model_memory |   inference_memory |   time |
+|---:|:-----------------------------|-------------:|:-------|:----------|:--------------|:---------------|:-----------|---------------:|-------------------:|-------:|
+|  0 | black-forest-labs/FLUX.1-dev |            4 | True   | True      | True          | fp8dqrow       | False      |         22.377 |             35.83  | 11.441 |
+|  1 | black-forest-labs/FLUX.1-dev |            1 | False  | True      | True          | fp8dqrow       | False      |         20.368 |             31.818 |  2.981 |
+|  2 | black-forest-labs/FLUX.1-dev |            4 | True   | True      | False         | fp8dqrow       | False      |         22.378 |             35.829 | 11.682 |
+|  3 | black-forest-labs/FLUX.1-dev |            1 | False  | True      | False         | fp8dqrow       | False      |         20.37  |             31.82  |  3.039 |
+|  4 | black-forest-labs/FLUX.1-dev |            4 | False  | True      | False         | fp8dqrow       | False      |         20.369 |             31.818 | 11.692 |
+|  5 | black-forest-labs/FLUX.1-dev |            4 | False  | True      | True          | fp8dqrow       | False      |         20.367 |             31.817 | 11.421 |
+|  6 | black-forest-labs/FLUX.1-dev |            1 | True   | True      | True          | fp8dqrow       | False      |         22.379 |             35.831 |  2.966 |
+|  7 | black-forest-labs/FLUX.1-dev |            1 | True   | True      | False         | fp8dqrow       | False      |         22.376 |             35.827 |  3.03  |
+
+</details>
+
 ### Trade-offs, trade-offs, and more trade-offs
 
 We know that the table included above is hard to parse. So, we wanted to include a couple of points that are worth noting. 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Optimize image and video generation with [`diffusers`](https://github.com/huggingface/diffusers), [`torchao`](https://github.com/pytorch/ao), combining `torch.compile()` 🔥** 
 
-We provide end-to-end inference and experimental training recipes to use `torchao` with `diffusers` in this repo. We demonstrate **48.86%** speedup on [Flux.1-Dev](https://huggingface.co/black-forest-labs/FLUX.1-dev)<sup>*</sup> and **21%** speedup on [CogVideoX-5b](https://huggingface.co/THUDM/CogVideoX-5b) when comparing *compiled* quantized models against their standard bf16 counterparts<sup>**</sup>. 
+We provide end-to-end inference and experimental training recipes to use `torchao` with `diffusers` in this repo. We demonstrate **53.88%** speedup on [Flux.1-Dev](https://huggingface.co/black-forest-labs/FLUX.1-dev)<sup>*</sup> and **21%** speedup on [CogVideoX-5b](https://huggingface.co/THUDM/CogVideoX-5b) when comparing *compiled* quantized models against their standard bf16 counterparts<sup>**</sup>. 
 
 <sub><sup>*</sup>The experiments were run on a single H100, 80 GB GPU.</sub>
 <sub><sup>**</sup>The experiments were run on a single A100, 80 GB GPU.</sub>

--- a/inference/benchmark_image.py
+++ b/inference/benchmark_image.py
@@ -6,16 +6,7 @@ torch.set_float32_matmul_precision("high")
 
 from diffusers import DiffusionPipeline
 
-from torchao.quantization import (
-    int4_weight_only,
-    int8_weight_only,
-    int8_dynamic_activation_int8_weight,
-    float8_dynamic_activation_float8_weight,
-    float8_weight_only,
-    quantize_,
-    autoquant,
-)
-from torchao.sparsity import sparsify_, int8_dynamic_activation_int8_semi_sparse_weight
+from torchao.quantization import quantize_, autoquant
 import argparse
 import json
 
@@ -55,14 +46,20 @@ def load_pipeline(
 
     if not sparsify:
         if quantization == "int8dq":
+            from torchao.quantization import int8_dynamic_activation_int8_weight
+
             quantize_(pipeline.transformer, int8_dynamic_activation_int8_weight())
             if compile_vae:
                 quantize_(pipeline.vae, int8_dynamic_activation_int8_weight())
         elif quantization == "int8wo":
+            from torchao.quantization import int8_weight_only
+
             quantize_(pipeline.transformer, int8_weight_only())
             if compile_vae:
                 quantize_(pipeline.vae, int8_weight_only())
         elif quantization == "int4wo":
+            from torchao.quantization import int4_weight_only
+
             quantize_(pipeline.transformer, int4_weight_only())
             if compile_vae:
                 quantize_(pipeline.vae, int4_weight_only())
@@ -73,10 +70,14 @@ def load_pipeline(
             if compile_vae:
                 quantize_(pipeline.vae, fp6_llm_weight_only())
         elif quantization == "fp8wo":
+            from torchao.quantization import float8_weight_only
+
             quantize_(pipeline.transformer, float8_weight_only())
             if compile_vae:
                 quantize_(pipeline.vae, float8_weight_only())
         elif quantization == "fp8dq":
+            from torchao.quantization import float8_dynamic_activation_float8_weight
+
             quantize_(pipeline.transformer, float8_dynamic_activation_float8_weight())
             if compile_vae:
                 quantize_(pipeline.vae, float8_dynamic_activation_float8_weight())
@@ -92,6 +93,8 @@ def load_pipeline(
                 pipeline.vae = autoquant(pipeline.vae, error_on_unseen=False)
 
     if sparsify:
+        from torchao.sparsity import sparsify_, int8_dynamic_activation_int8_semi_sparse_weight
+
         sparsify_(pipeline.transformer, int8_dynamic_activation_int8_semi_sparse_weight())
         if compile_vae:
             sparsify_(pipeline.vae, int8_dynamic_activation_int8_semi_sparse_weight())

--- a/inference/benchmark_image.py
+++ b/inference/benchmark_image.py
@@ -68,6 +68,7 @@ def load_pipeline(
                 quantize_(pipeline.vae, int4_weight_only())
         elif quantization == "fp6":
             from torchao.prototype.quant_llm import fp6_llm_weight_only
+
             quantize_(pipeline.transformer, fp6_llm_weight_only())
             if compile_vae:
                 quantize_(pipeline.vae, fp6_llm_weight_only())
@@ -79,6 +80,12 @@ def load_pipeline(
             quantize_(pipeline.transformer, float8_dynamic_activation_float8_weight())
             if compile_vae:
                 quantize_(pipeline.vae, float8_dynamic_activation_float8_weight())
+        elif quantization == "fp8dqrow":
+            from torchao.quantization.quant_api import PerRow
+
+            quantize_(pipeline.transformer, float8_dynamic_activation_float8_weight(granularity=PerRow()))
+            if compile_vae:
+                quantize_(pipeline.vae, float8_dynamic_activation_float8_weight(granularity=PerRow()))
         elif quantization == "autoquant":
             pipeline.transformer = autoquant(pipeline.transformer, error_on_unseen=False)
             if compile_vae:
@@ -168,7 +175,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--quantization",
         default="None",
-        choices=["int8dq", "int8wo", "int4wo", "autoquant", "fp6", "fp8wo", "fp8dq", "None"],
+        choices=["int8dq", "int8wo", "int4wo", "autoquant", "fp6", "fp8wo", "fp8dq", "fp8dqrow", "None"],
         help="Which quantization technique to apply",
     )
     parser.add_argument("--sparsify", action="store_true")

--- a/inference/benchmark_video.py
+++ b/inference/benchmark_video.py
@@ -16,7 +16,7 @@ from torchao.quantization import (
     int8_dynamic_activation_int8_semi_sparse_weight,
     int4_weight_only,
     float8_dynamic_activation_float8_weight,
-    float8_weight_only
+    float8_weight_only,
 )
 from torchao.sparsity import sparsify_
 from torchao.prototype.quant_llm import fp6_llm_weight_only


### PR DESCRIPTION
Thanks to @drisspg. 

Will update the numbers. 

|    | ckpt_id                      |   batch_size | fuse   | compile   | compile_vae   | quantization   | sparsify   |   model_memory |   inference_memory |   time |
|---:|:-----------------------------|-------------:|:-------|:----------|:--------------|:---------------|:-----------|---------------:|-------------------:|-------:|
|  0 | black-forest-labs/FLUX.1-dev |            4 | True   | True      | True          | fp8dqrow       | False      |         22.377 |             35.83  | 11.441 |
|  1 | black-forest-labs/FLUX.1-dev |            1 | False  | True      | True          | fp8dqrow       | False      |         20.368 |             31.818 |  2.981 |
|  2 | black-forest-labs/FLUX.1-dev |            4 | True   | True      | False         | fp8dqrow       | False      |         22.378 |             35.829 | 11.682 |
|  3 | black-forest-labs/FLUX.1-dev |            1 | False  | True      | False         | fp8dqrow       | False      |         20.37  |             31.82  |  3.039 |
|  4 | black-forest-labs/FLUX.1-dev |            4 | False  | True      | False         | fp8dqrow       | False      |         20.369 |             31.818 | 11.692 |
|  5 | black-forest-labs/FLUX.1-dev |            4 | False  | True      | True          | fp8dqrow       | False      |         20.367 |             31.817 | 11.421 |
|  6 | black-forest-labs/FLUX.1-dev |            1 | True   | True      | True          | fp8dqrow       | False      |         22.379 |             35.831 |  2.966 |
|  7 | black-forest-labs/FLUX.1-dev |            1 | True   | True      | False         | fp8dqrow       | False      |         22.376 |             35.827 |  3.03  |