### PR TITLE
Added torchao version guards for floatx

### DIFF
--- a/inference/benchmark_image.py
+++ b/inference/benchmark_image.py
@@ -10,17 +10,7 @@ from torchao.quantization import quantize_, autoquant
 import argparse
 import json
 
-<<<<<<< HEAD
-from utils import (
-    cleanup_tmp_directory,
-    benchmark_fn,
-    pretty_print_results,
-    reset_memory,
-    bytes_to_giga_bytes,
-)
-=======
 from utils import cleanup_tmp_directory, benchmark_fn, pretty_print_results, reset_memory, bytes_to_giga_bytes
->>>>>>> 0454a5c (Added torchao version guards for floatx)
 from packaging import version
 import importlib
 
@@ -43,9 +33,7 @@ def load_pipeline(
     sparsify: bool,
     compile_vae: bool = False,
 ) -> DiffusionPipeline:
-    pipeline = DiffusionPipeline.from_pretrained(
-        ckpt_id, torch_dtype=torch.bfloat16
-    ).to("cuda")
+    pipeline = DiffusionPipeline.from_pretrained(ckpt_id, torch_dtype=torch.bfloat16).to("cuda")
 
     if fuse_attn_projections:
         pipeline.transformer.fuse_qkv_projections()
@@ -54,14 +42,10 @@ def load_pipeline(
 
     if quantization == "autoquant" and compile:
         pipeline.transformer.to(memory_format=torch.channels_last)
-        pipeline.transformer = torch.compile(
-            pipeline.transformer, mode="max-autotune", fullgraph=True
-        )
+        pipeline.transformer = torch.compile(pipeline.transformer, mode="max-autotune", fullgraph=True)
         if compile_vae:
             pipeline.vae.to(memory_format=torch.channels_last)
-            pipeline.vae.decode = torch.compile(
-                pipeline.vae.decode, mode="max-autotune", fullgraph=True
-            )
+            pipeline.vae.decode = torch.compile(pipeline.vae.decode, mode="max-autotune", fullgraph=True)
 
     if not sparsify:
         if quantization == "int8dq":
@@ -131,19 +115,11 @@ def load_pipeline(
             from torchao.quantization import float8_dynamic_activation_float8_weight
             from torchao.quantization.quant_api import PerRow
 
-            quantize_(
-                pipeline.transformer,
-                float8_dynamic_activation_float8_weight(granularity=PerRow()),
-            )
+            quantize_(pipeline.transformer, float8_dynamic_activation_float8_weight(granularity=PerRow()))
             if compile_vae:
-                quantize_(
-                    pipeline.vae,
-                    float8_dynamic_activation_float8_weight(granularity=PerRow()),
-                )
+                quantize_(pipeline.vae, float8_dynamic_activation_float8_weight(granularity=PerRow()))
         elif quantization == "autoquant":
-            pipeline.transformer = autoquant(
-                pipeline.transformer, error_on_unseen=False
-            )
+            pipeline.transformer = autoquant(pipeline.transformer, error_on_unseen=False)
             if compile_vae:
                 pipeline.vae = autoquant(pipeline.vae, error_on_unseen=False)
 
@@ -152,26 +128,16 @@ def load_pipeline(
         from torchao.dtypes import SemiSparseLayout
         from torchao.quantization import int8_dynamic_activation_int8_weight
 
-        sparsify_(
-            pipeline.transformer,
-            int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()),
-        )
+        sparsify_(pipeline.transformer, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()))
         if compile_vae:
-            sparsify_(
-                pipeline.vae,
-                int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()),
-            )
+            sparsify_(pipeline.vae, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()))
 
     if quantization != "autoquant" and compile:
         pipeline.transformer.to(memory_format=torch.channels_last)
-        pipeline.transformer = torch.compile(
-            pipeline.transformer, mode="max-autotune", fullgraph=True
-        )
+        pipeline.transformer = torch.compile(pipeline.transformer, mode="max-autotune", fullgraph=True)
         if compile_vae:
             pipeline.vae.to(memory_format=torch.channels_last)
-            pipeline.vae.decode = torch.compile(
-                pipeline.vae.decode, mode="max-autotune", fullgraph=True
-            )
+            pipeline.vae.decode = torch.compile(pipeline.vae.decode, mode="max-autotune", fullgraph=True)
 
     pipeline.set_progress_bar_config(disable=True)
     return pipeline
@@ -240,16 +206,8 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether or not to fuse the QKV projection layers into one larger layer.",
     )
-    parser.add_argument(
-        "--compile",
-        action="store_true",
-        help="Whether or not to torch.compile the models.",
-    )
-    parser.add_argument(
-        "--compile_vae",
-        action="store_true",
-        help="If compiling, should VAE be compiled too?",
-    )
+    parser.add_argument("--compile", action="store_true", help="Whether or not to torch.compile the models.")
+    parser.add_argument("--compile_vae", action="store_true", help="If compiling, should VAE be compiled too?")
     parser.add_argument(
         "--quantization",
         default="None",

--- a/inference/benchmark_image.py
+++ b/inference/benchmark_image.py
@@ -10,7 +10,15 @@ from torchao.quantization import quantize_, autoquant
 import argparse
 import json
 
-from utils import cleanup_tmp_directory, benchmark_fn, pretty_print_results, reset_memory, bytes_to_giga_bytes
+from utils import (
+    cleanup_tmp_directory,
+    benchmark_fn,
+    pretty_print_results,
+    reset_memory,
+    bytes_to_giga_bytes,
+)
+from packaging import version
+import importlib
 
 
 PROMPT = "Eiffel Tower was Made up of more than 2 million translucent straws to look like a cloud, with the bell tower at the top of the building, Michel installed huge foam-making machines in the forest to blow huge amounts of unpredictable wet clouds in the building's classic architecture."
@@ -20,6 +28,7 @@ PREFIXES = {
     "fal/AuraFlow": "auraflow",
     "black-forest-labs/FLUX.1-dev": "flux-dev",
 }
+TORCHAO_VERSION = version.parse(importlib.metadata.version("torchao"))
 
 
 def load_pipeline(
@@ -30,7 +39,9 @@ def load_pipeline(
     sparsify: bool,
     compile_vae: bool = False,
 ) -> DiffusionPipeline:
-    pipeline = DiffusionPipeline.from_pretrained(ckpt_id, torch_dtype=torch.bfloat16).to("cuda")
+    pipeline = DiffusionPipeline.from_pretrained(
+        ckpt_id, torch_dtype=torch.bfloat16
+    ).to("cuda")
 
     if fuse_attn_projections:
         pipeline.transformer.fuse_qkv_projections()
@@ -39,10 +50,14 @@ def load_pipeline(
 
     if quantization == "autoquant" and compile:
         pipeline.transformer.to(memory_format=torch.channels_last)
-        pipeline.transformer = torch.compile(pipeline.transformer, mode="max-autotune", fullgraph=True)
+        pipeline.transformer = torch.compile(
+            pipeline.transformer, mode="max-autotune", fullgraph=True
+        )
         if compile_vae:
             pipeline.vae.to(memory_format=torch.channels_last)
-            pipeline.vae.decode = torch.compile(pipeline.vae.decode, mode="max-autotune", fullgraph=True)
+            pipeline.vae.decode = torch.compile(
+                pipeline.vae.decode, mode="max-autotune", fullgraph=True
+            )
 
     if not sparsify:
         if quantization == "int8dq":
@@ -64,25 +79,38 @@ def load_pipeline(
             if compile_vae:
                 quantize_(pipeline.vae, int4_weight_only())
         elif quantization == "fp6_e3m2":
-            from torchao.quantization import fpx_weight_only
+            if TORCHAO_VERSION <= version.parse("0.14.1"):
+                from torchao.quantization import fpx_weight_only
 
-            quantize_(pipeline.transformer, fpx_weight_only(3, 2))
-            if compile_vae:
-                quantize_(pipeline.vae, fpx_weight_only(3, 2))
-
+                quantize_(pipeline.transformer, fpx_weight_only(3, 2))
+                if compile_vae:
+                    quantize_(pipeline.vae, fpx_weight_only(3, 2))
+            else:
+                raise ValueError(
+                    "Floating point X-bit quantization is not supported in torchao > 0.14.1"
+                )
         elif quantization == "fp5_e2m2":
-            from torchao.quantization import fpx_weight_only
+            if TORCHAO_VERSION <= version.parse("0.14.1"):
+                from torchao.quantization import fpx_weight_only
 
-            quantize_(pipeline.transformer, fpx_weight_only(2, 2))
-            if compile_vae:
-                quantize_(pipeline.vae, fpx_weight_only(2, 2))
-
+                quantize_(pipeline.transformer, fpx_weight_only(2, 2))
+                if compile_vae:
+                    quantize_(pipeline.vae, fpx_weight_only(2, 2))
+            else:
+                raise ValueError(
+                    "Floating point X-bit quantization is not supported in torchao > 0.14.1"
+                )
         elif quantization == "fp4_e2m1":
-            from torchao.quantization import fpx_weight_only
+            if TORCHAO_VERSION <= version.parse("0.14.1"):
+                from torchao.quantization import fpx_weight_only
 
-            quantize_(pipeline.transformer, fpx_weight_only(2, 1))
-            if compile_vae:
-                quantize_(pipeline.vae, fpx_weight_only(2, 1))
+                quantize_(pipeline.transformer, fpx_weight_only(2, 1))
+                if compile_vae:
+                    quantize_(pipeline.vae, fpx_weight_only(2, 1))
+            else:
+                raise ValueError(
+                    "Floating point X-bit quantization is not supported in torchao > 0.14.1"
+                )
         elif quantization == "fp8wo":
             from torchao.quantization import float8_weight_only
 
@@ -99,11 +127,19 @@ def load_pipeline(
             from torchao.quantization import float8_dynamic_activation_float8_weight
             from torchao.quantization.quant_api import PerRow
 
-            quantize_(pipeline.transformer, float8_dynamic_activation_float8_weight(granularity=PerRow()))
+            quantize_(
+                pipeline.transformer,
+                float8_dynamic_activation_float8_weight(granularity=PerRow()),
+            )
             if compile_vae:
-                quantize_(pipeline.vae, float8_dynamic_activation_float8_weight(granularity=PerRow()))
+                quantize_(
+                    pipeline.vae,
+                    float8_dynamic_activation_float8_weight(granularity=PerRow()),
+                )
         elif quantization == "autoquant":
-            pipeline.transformer = autoquant(pipeline.transformer, error_on_unseen=False)
+            pipeline.transformer = autoquant(
+                pipeline.transformer, error_on_unseen=False
+            )
             if compile_vae:
                 pipeline.vae = autoquant(pipeline.vae, error_on_unseen=False)
 
@@ -112,16 +148,26 @@ def load_pipeline(
         from torchao.dtypes import SemiSparseLayout
         from torchao.quantization import int8_dynamic_activation_int8_weight
 
-        sparsify_(pipeline.transformer, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()))
+        sparsify_(
+            pipeline.transformer,
+            int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()),
+        )
         if compile_vae:
-            sparsify_(pipeline.vae, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()))
+            sparsify_(
+                pipeline.vae,
+                int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()),
+            )
 
     if quantization != "autoquant" and compile:
         pipeline.transformer.to(memory_format=torch.channels_last)
-        pipeline.transformer = torch.compile(pipeline.transformer, mode="max-autotune", fullgraph=True)
+        pipeline.transformer = torch.compile(
+            pipeline.transformer, mode="max-autotune", fullgraph=True
+        )
         if compile_vae:
             pipeline.vae.to(memory_format=torch.channels_last)
-            pipeline.vae.decode = torch.compile(pipeline.vae.decode, mode="max-autotune", fullgraph=True)
+            pipeline.vae.decode = torch.compile(
+                pipeline.vae.decode, mode="max-autotune", fullgraph=True
+            )
 
     pipeline.set_progress_bar_config(disable=True)
     return pipeline
@@ -190,8 +236,16 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether or not to fuse the QKV projection layers into one larger layer.",
     )
-    parser.add_argument("--compile", action="store_true", help="Whether or not to torch.compile the models.")
-    parser.add_argument("--compile_vae", action="store_true", help="If compiling, should VAE be compiled too?")
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        help="Whether or not to torch.compile the models.",
+    )
+    parser.add_argument(
+        "--compile_vae",
+        action="store_true",
+        help="If compiling, should VAE be compiled too?",
+    )
     parser.add_argument(
         "--quantization",
         default="None",

--- a/inference/benchmark_image.py
+++ b/inference/benchmark_image.py
@@ -10,6 +10,7 @@ from torchao.quantization import quantize_, autoquant
 import argparse
 import json
 
+<<<<<<< HEAD
 from utils import (
     cleanup_tmp_directory,
     benchmark_fn,
@@ -17,6 +18,9 @@ from utils import (
     reset_memory,
     bytes_to_giga_bytes,
 )
+=======
+from utils import cleanup_tmp_directory, benchmark_fn, pretty_print_results, reset_memory, bytes_to_giga_bytes
+>>>>>>> 0454a5c (Added torchao version guards for floatx)
 from packaging import version
 import importlib
 

--- a/inference/benchmark_video.py
+++ b/inference/benchmark_video.py
@@ -46,9 +46,7 @@ CONVERT_DTYPE = {
     "int4dq": lambda module: quantize_(module, int8_dynamic_activation_int4_weight()),
     "int4wo": lambda module: quantize_(module, int4_weight_only()),
     "autoquant": lambda module: autoquant(module, error_on_unseen=False),
-    "sparsify": lambda module: sparsify_(
-        module, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())
-    ),
+    "sparsify": lambda module: sparsify_(module, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())),
 }
 if TORCHAO_VERSION <= version.parse("0.14.1"):
     CONVERT_DTYPE.update(
@@ -70,12 +68,8 @@ if TORCHAO_VERSION <= version.parse("0.14.1"):
 
 def load_pipeline(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
     # 1. Load pipeline
-    pipe = CogVideoXPipeline.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(
-        device
-    )
-    pipe.scheduler = CogVideoXDDIMScheduler.from_config(
-        pipe.scheduler.config, timestep_spacing="trailing"
-    )
+    pipe = CogVideoXPipeline.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(device)
+    pipe.scheduler = CogVideoXDDIMScheduler.from_config(pipe.scheduler.config, timestep_spacing="trailing")
     pipe.set_progress_bar_config(disable=True)
 
     if fuse_qkv:
@@ -84,9 +78,7 @@ def load_pipeline(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
     # 2. Quantize and compile
     if dtype == "autoquant" and compile:
         pipe.transformer.to(memory_format=torch.channels_last)
-        pipe.transformer = torch.compile(
-            pipe.transformer, mode="max-autotune", fullgraph=True
-        )
+        pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune", fullgraph=True)
         # VAE cannot be compiled due to: https://gist.github.com/a-r-r-o-w/5183d75e452a368fd17448fcc810bd3f#file-test_cogvideox_torch_compile-py-L30
 
     text_encoder_return = CONVERT_DTYPE[dtype](pipe.text_encoder)
@@ -104,9 +96,7 @@ def load_pipeline(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
 
     if dtype != "autoquant" and compile:
         pipe.transformer.to(memory_format=torch.channels_last)
-        pipe.transformer = torch.compile(
-            pipe.transformer, mode="max-autotune", fullgraph=True
-        )
+        pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune", fullgraph=True)
         # VAE cannot be compiled due to: https://gist.github.com/a-r-r-o-w/5183d75e452a368fd17448fcc810bd3f#file-test_cogvideox_torch_compile-py-L30
 
     return pipe
@@ -230,9 +220,7 @@ def get_args():
         ],
         help="Inference or Quantization type.",
     )
-    parser.add_argument(
-        "--device", type=str, default="cuda", help="Device to run inference on."
-    )
+    parser.add_argument("--device", type=str, default="cuda", help="Device to run inference on.")
     parser.add_argument(
         "--quantize_vae",
         action="store_true",
@@ -257,12 +245,5 @@ def get_args():
 if __name__ == "__main__":
     args = get_args()
 
-    main(
-        args.model_id,
-        args.dtype,
-        args.device,
-        args.quantize_vae,
-        args.compile,
-        args.fuse_qkv,
-    )
+    main(args.model_id, args.dtype, args.device, args.quantize_vae, args.compile, args.fuse_qkv)
     cleanup_tmp_directory()

--- a/inference/benchmark_video.py
+++ b/inference/benchmark_video.py
@@ -56,14 +56,6 @@ if TORCHAO_VERSION <= version.parse("0.14.1"):
             "fp4_e2m1": lambda module: quantize_(module, fpx_weight_only(2, 1)),
         }
     )
-if TORCHAO_VERSION <= version.parse("0.14.1"):
-    CONVERT_DTYPE.update(
-        {
-            "fp6_e3m2": lambda module: quantize_(module, fpx_weight_only(3, 2)),
-            "fp5_e2m2": lambda module: quantize_(module, fpx_weight_only(2, 2)),
-            "fp4_e2m1": lambda module: quantize_(module, fpx_weight_only(2, 1)),
-        }
-    )
 
 
 def load_pipeline(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
@@ -133,16 +125,6 @@ def main(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
         raise ValueError(
             "Floating point X-bit quantization is not supported in torchao > 0.14.1"
         )
-
-    if TORCHAO_VERSION > version.parse("0.14.1") and dtype in [
-        "fp6_e3m2",
-        "fp5_e2m2",
-        "fp4_e2m1",
-    ]:
-        raise ValueError(
-            "Floating point X-bit quantization is not supported in torchao > 0.14.1"
-        )
-
     reset_memory(device)
 
     # 1. Load pipeline

--- a/inference/benchmark_video.py
+++ b/inference/benchmark_video.py
@@ -16,14 +16,25 @@ from torchao.quantization import (
     int4_weight_only,
     float8_dynamic_activation_float8_weight,
     float8_weight_only,
-    fpx_weight_only,
 )
 from torchao.quantization.quant_api import PerRow
 from torchao.sparsity import sparsify_
 from torchao.dtypes import SemiSparseLayout
 
 
-from utils import cleanup_tmp_directory, benchmark_fn, pretty_print_results, print_memory, reset_memory
+from utils import (
+    cleanup_tmp_directory,
+    benchmark_fn,
+    pretty_print_results,
+    print_memory,
+    reset_memory,
+)
+from packaging import version
+import importlib
+
+TORCHAO_VERSION = version.parse(importlib.metadata.version("torchao"))
+if TORCHAO_VERSION <= version.parse("0.14.1"):
+    from torchao.quantization import fpx_weight_only
 
 # Set high precision for float32 matrix multiplications.
 # This setting optimizes performance on NVIDIA GPUs with Ampere architecture (e.g., A100, RTX 30 series) or newer.
@@ -34,24 +45,39 @@ CONVERT_DTYPE = {
     "fp16": lambda module: module.to(dtype=torch.float16),
     "bf16": lambda module: module.to(dtype=torch.bfloat16),
     "fp8wo": lambda module: quantize_(module, float8_weight_only()),
-    "fp8dq": lambda module: quantize_(module, float8_dynamic_activation_float8_weight()),
-    "fp8dqrow": lambda module: quantize_(module, float8_dynamic_activation_float8_weight(granularity=PerRow())),
-    "fp6_e3m2": lambda module: quantize_(module, fpx_weight_only(3, 2)),
-    "fp5_e2m2": lambda module: quantize_(module, fpx_weight_only(2, 2)),
-    "fp4_e2m1": lambda module: quantize_(module, fpx_weight_only(2, 1)),
+    "fp8dq": lambda module: quantize_(
+        module, float8_dynamic_activation_float8_weight()
+    ),
+    "fp8dqrow": lambda module: quantize_(
+        module, float8_dynamic_activation_float8_weight(granularity=PerRow())
+    ),
     "int8wo": lambda module: quantize_(module, int8_weight_only()),
     "int8dq": lambda module: quantize_(module, int8_dynamic_activation_int8_weight()),
     "int4dq": lambda module: quantize_(module, int8_dynamic_activation_int4_weight()),
     "int4wo": lambda module: quantize_(module, int4_weight_only()),
     "autoquant": lambda module: autoquant(module, error_on_unseen=False),
-    "sparsify": lambda module: sparsify_(module, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())),
+    "sparsify": lambda module: sparsify_(
+        module, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())
+    ),
 }
+if TORCHAO_VERSION <= version.parse("0.14.1"):
+    CONVERT_DTYPE.update(
+        {
+            "fp6_e3m2": lambda module: quantize_(module, fpx_weight_only(3, 2)),
+            "fp5_e2m2": lambda module: quantize_(module, fpx_weight_only(2, 2)),
+            "fp4_e2m1": lambda module: quantize_(module, fpx_weight_only(2, 1)),
+        }
+    )
 
 
 def load_pipeline(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
     # 1. Load pipeline
-    pipe = CogVideoXPipeline.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(device)
-    pipe.scheduler = CogVideoXDDIMScheduler.from_config(pipe.scheduler.config, timestep_spacing="trailing")
+    pipe = CogVideoXPipeline.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(
+        device
+    )
+    pipe.scheduler = CogVideoXDDIMScheduler.from_config(
+        pipe.scheduler.config, timestep_spacing="trailing"
+    )
     pipe.set_progress_bar_config(disable=True)
 
     if fuse_qkv:
@@ -60,7 +86,9 @@ def load_pipeline(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
     # 2. Quantize and compile
     if dtype == "autoquant" and compile:
         pipe.transformer.to(memory_format=torch.channels_last)
-        pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune", fullgraph=True)
+        pipe.transformer = torch.compile(
+            pipe.transformer, mode="max-autotune", fullgraph=True
+        )
         # VAE cannot be compiled due to: https://gist.github.com/a-r-r-o-w/5183d75e452a368fd17448fcc810bd3f#file-test_cogvideox_torch_compile-py-L30
 
     text_encoder_return = CONVERT_DTYPE[dtype](pipe.text_encoder)
@@ -78,7 +106,9 @@ def load_pipeline(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
 
     if dtype != "autoquant" and compile:
         pipe.transformer.to(memory_format=torch.channels_last)
-        pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune", fullgraph=True)
+        pipe.transformer = torch.compile(
+            pipe.transformer, mode="max-autotune", fullgraph=True
+        )
         # VAE cannot be compiled due to: https://gist.github.com/a-r-r-o-w/5183d75e452a368fd17448fcc810bd3f#file-test_cogvideox_torch_compile-py-L30
 
     return pipe
@@ -101,12 +131,23 @@ def run_inference(pipe):
         guidance_scale=guidance_scale,
         use_dynamic_cfg=True,
         num_inference_steps=num_inference_steps,
-        generator=torch.Generator().manual_seed(3047),  # https://arxiv.org/abs/2109.08203
+        generator=torch.Generator().manual_seed(
+            3047
+        ),  # https://arxiv.org/abs/2109.08203
     )
     return video
 
 
 def main(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
+    if TORCHAO_VERSION > version.parse("0.14.1") and dtype in [
+        "fp6_e3m2",
+        "fp5_e2m2",
+        "fp4_e2m1",
+    ]:
+        raise ValueError(
+            "Floating point X-bit quantization is not supported in torchao > 0.14.1"
+        )
+
     reset_memory(device)
 
     # 1. Load pipeline
@@ -184,7 +225,9 @@ def get_args():
         ],
         help="Inference or Quantization type.",
     )
-    parser.add_argument("--device", type=str, default="cuda", help="Device to run inference on.")
+    parser.add_argument(
+        "--device", type=str, default="cuda", help="Device to run inference on."
+    )
     parser.add_argument(
         "--quantize_vae",
         action="store_true",
@@ -209,5 +252,12 @@ def get_args():
 if __name__ == "__main__":
     args = get_args()
 
-    main(args.model_id, args.dtype, args.device, args.quantize_vae, args.compile, args.fuse_qkv)
+    main(
+        args.model_id,
+        args.dtype,
+        args.device,
+        args.quantize_vae,
+        args.compile,
+        args.fuse_qkv,
+    )
     cleanup_tmp_directory()

--- a/inference/benchmark_video.py
+++ b/inference/benchmark_video.py
@@ -22,13 +22,7 @@ from torchao.sparsity import sparsify_
 from torchao.dtypes import SemiSparseLayout
 
 
-from utils import (
-    cleanup_tmp_directory,
-    benchmark_fn,
-    pretty_print_results,
-    print_memory,
-    reset_memory,
-)
+from utils import cleanup_tmp_directory, benchmark_fn, pretty_print_results, print_memory, reset_memory
 from packaging import version
 import importlib
 
@@ -45,12 +39,8 @@ CONVERT_DTYPE = {
     "fp16": lambda module: module.to(dtype=torch.float16),
     "bf16": lambda module: module.to(dtype=torch.bfloat16),
     "fp8wo": lambda module: quantize_(module, float8_weight_only()),
-    "fp8dq": lambda module: quantize_(
-        module, float8_dynamic_activation_float8_weight()
-    ),
-    "fp8dqrow": lambda module: quantize_(
-        module, float8_dynamic_activation_float8_weight(granularity=PerRow())
-    ),
+    "fp8dq": lambda module: quantize_(module, float8_dynamic_activation_float8_weight()),
+    "fp8dqrow": lambda module: quantize_(module, float8_dynamic_activation_float8_weight(granularity=PerRow())),
     "int8wo": lambda module: quantize_(module, int8_weight_only()),
     "int8dq": lambda module: quantize_(module, int8_dynamic_activation_int8_weight()),
     "int4dq": lambda module: quantize_(module, int8_dynamic_activation_int4_weight()),
@@ -60,6 +50,14 @@ CONVERT_DTYPE = {
         module, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())
     ),
 }
+if TORCHAO_VERSION <= version.parse("0.14.1"):
+    CONVERT_DTYPE.update(
+        {
+            "fp6_e3m2": lambda module: quantize_(module, fpx_weight_only(3, 2)),
+            "fp5_e2m2": lambda module: quantize_(module, fpx_weight_only(2, 2)),
+            "fp4_e2m1": lambda module: quantize_(module, fpx_weight_only(2, 1)),
+        }
+    )
 if TORCHAO_VERSION <= version.parse("0.14.1"):
     CONVERT_DTYPE.update(
         {
@@ -131,14 +129,21 @@ def run_inference(pipe):
         guidance_scale=guidance_scale,
         use_dynamic_cfg=True,
         num_inference_steps=num_inference_steps,
-        generator=torch.Generator().manual_seed(
-            3047
-        ),  # https://arxiv.org/abs/2109.08203
+        generator=torch.Generator().manual_seed(3047),  # https://arxiv.org/abs/2109.08203
     )
     return video
 
 
 def main(model_id, dtype, device, quantize_vae, compile, fuse_qkv):
+    if TORCHAO_VERSION > version.parse("0.14.1") and dtype in [
+        "fp6_e3m2",
+        "fp5_e2m2",
+        "fp4_e2m1",
+    ]:
+        raise ValueError(
+            "Floating point X-bit quantization is not supported in torchao > 0.14.1"
+        )
+
     if TORCHAO_VERSION > version.parse("0.14.1") and dtype in [
         "fp6_e3m2",
         "fp5_e2m2",


### PR DESCRIPTION
Motivation: TorchAO not supporting floatx in version > 0.14.1

Summary: Added version guards in benchmark_image.py Added version guards in benchmark_video.py

Test Plan: Run benchmark_image.py/benchmark_video.py